### PR TITLE
[WIP] Osx support

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,12 +1,12 @@
 .PHONY: clean
-BACKENDS = artnet.so midi.so osc.so loopback.so evdev.so
+BACKENDS = artnet.so osc.so loopback.so
 OBJS = config.o backend.o plugin.o
 PLUGINDIR = "\"./\""
 
 CFLAGS ?= -g -Wall
 #CFLAGS += -DDEBUG
 %.so: CFLAGS += -fPIC
-%.so: LDFLAGS += -shared
+%.so: LDFLAGS += -shared -undefined dynamic_lookup
 
 midimonster: LDLIBS = -ldl
 midimonster: CFLAGS += -rdynamic -DPLUGINS=$(PLUGINDIR)
@@ -20,7 +20,7 @@ evdev.so: LDLIBS = $(shell pkg-config --libs libevdev)
 
 all: midimonster $(BACKENDS)
 
-midimonster: midimonster.h $(OBJS)
+midimonster: midimonster.c $(OBJS)
 
 clean:
 	$(RM) midimonster

--- a/midimonster.h
+++ b/midimonster.h
@@ -4,6 +4,28 @@
 #include <stdlib.h>
 #include <stdint.h>
 #define max(a,b) (((a) > (b)) ? (a) : (b))
+
+#ifdef __APPLE__
+
+#include <libkern/OSByteOrder.h>
+
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#endif
+
 #ifdef DEBUG
 	#define DBGPF(format, ...) fprintf(stderr, (format), __VA_ARGS__)
 	#define DBG(message) fprintf(stderr, "%s", (message))


### PR DESCRIPTION
Hello,

This is rough and incomplete because my makefile foo is pretty not great and I didn't want to try and figure out conditionals. However, it does have the changes necessary to make midimonster at least partially work on os x. 

Changes:

- Remove midi+evdev (should be conditional, at least for midi we should look for an osx replacement solution..)
- clang requires linker flag -undefined dynamic_lookup so it doesn't complain about not seeing symbols when building libraries.
- For whatever reason with clang, the midimonster target needs to be passed the c file instead of the header.  passing the header also passes the c file, and then we get errors due to multiple targets on command line with -o.
- Define htobe/etc as mac equivilents.  Found here: https://github.com/zeromq/zmqpp/issues/164

One outstanding issue is that binding needs a specific address in config files.  bind * 8000 does not work: Failed to get socket info for * port 8000: nodename nor servname provided, or not known

I may keep poking at this over the weekend, but if not wanted to share my efforts so far.

Thanks for your work on the underlying program, it's fantastic!