### PR TITLE
Output 0 on NoteOff

### DIFF
--- a/backends/midi.c
+++ b/backends/midi.c
@@ -259,14 +259,20 @@ static int midi_handle(size_t num, managed_fd* fds){
 		ident.label = 0;
 		switch(ev->type){
 			case SND_SEQ_EVENT_NOTEON:
-			case SND_SEQ_EVENT_NOTEOFF:
-			case SND_SEQ_EVENT_NOTE:
 				ident.fields.type = note;
 				ident.fields.channel = ev->data.note.channel;
 				ident.fields.control = ev->data.note.note;
 				val.normalised = (double)ev->data.note.velocity / 127.0;
 				event_type = "note";
 				break;
+			case SND_SEQ_EVENT_NOTEOFF:
+				ident.fields.type = note;
+				ident.fields.channel = ev->data.note.channel;
+				ident.fields.control = ev->data.note.note;
+				val.normalised = (double)0;
+				event_type = "note";
+				break;
+			case SND_SEQ_EVENT_NOTE:
 			case SND_SEQ_EVENT_KEYPRESS:
 				ident.fields.type = pressure;
 				ident.fields.channel = ev->data.note.channel;

--- a/backends/midi.c
+++ b/backends/midi.c
@@ -259,20 +259,17 @@ static int midi_handle(size_t num, managed_fd* fds){
 		ident.label = 0;
 		switch(ev->type){
 			case SND_SEQ_EVENT_NOTEON:
+			case SND_SEQ_EVENT_NOTEOFF:
+			case SND_SEQ_EVENT_NOTE:
 				ident.fields.type = note;
 				ident.fields.channel = ev->data.note.channel;
 				ident.fields.control = ev->data.note.note;
 				val.normalised = (double)ev->data.note.velocity / 127.0;
+				if(ev->type == SND_SEQ_EVENT_NOTEOFF){
+   					val.normalised = 0;
+				}
 				event_type = "note";
 				break;
-			case SND_SEQ_EVENT_NOTEOFF:
-				ident.fields.type = note;
-				ident.fields.channel = ev->data.note.channel;
-				ident.fields.control = ev->data.note.note;
-				val.normalised = (double)0;
-				event_type = "note";
-				break;
-			case SND_SEQ_EVENT_NOTE:
 			case SND_SEQ_EVENT_KEYPRESS:
 				ident.fields.type = pressure;
 				ident.fields.channel = ev->data.note.channel;


### PR DESCRIPTION
Changes the MIDI behavior to always output 0 on NoteOff.

Some devices send MIDI NoteOff commands with a velocity of 127 (Example: Akai APC20). Previously this would result in an output stuck at 1 / On