### PR TITLE
PRH examples

### DIFF
--- a/configs/i3msg.lua
+++ b/configs/i3msg.lua
@@ -1,0 +1,75 @@
+--Simple lua OS examples by Paul Hedderly
+-- PREREQUISITES:
+-- 	luarocks install luasocket # optional if you will use your own connectors (see below)
+-- 	luarocks install luabitop  # you don't need this for lua 5.3
+-- 	luarocks install luasec    # you don't need this if you don't want to use SSL connections
+-- 	luarocks install luamqtt
+
+-- Example - A lot of these will depend on other configs and will need to be localised
+-- 	[lua i3msg]
+--	script = confgs/i3msg.lua
+--	default-handler = i3msg
+--
+--		nanomap.{1..10} > i3msg.workspace.{1..10} -- Jump to i3 workspace
+--		nanomap.10 > i3msg.muteall
+--		nanomap.11 > i3msg.run.pasink
+--		nanomap.12 > i3msg.showhide.retext
+--		nanomap.13 > i3msg.showhide.paprefs
+--		nanomap.14 > i3msg.showhide.pavucontrol
+--		nanomap.15 > i3msg.showhide.keepassxc
+--		nanomap.16 > i3msg.showhide.microsoft teams - insiders
+
+--		trackpad.gestureoo852 > i3msg.macro.volup -- see my trackpad.lua example
+--		trackpad.gestureoo25> i3msg.macro.voldown
+
+function i3msg(v) -- Use a default function - then you can use any input channel name
+
+    m=0.31
+    M=0.99
+    A = - M*m^2 / (M^2 - 2*m*M)
+    B = M*m^2 / (M^2 - 2*m*M)
+    C = math.log((M - m)^2 / m^2)
+    inchan=input_channel()
+    first=inchan:gsub("%..*","")
+    last=inchan:gsub('^.-%.',"")
+
+    if (v==0) then return; end -- Here were do not care that the control was released
+
+    if (inchan == "macro.myadminpass") then
+	    os.execute("/home/user/bin/macroscripttotypemyadminpassword")
+
+    elseif (first == "workspace") then
+	    -- print("i3-msg workspace number "..last)
+	    os.execute("i3-msg workspace number "..last)
+
+    elseif (first=="showhide") then
+	    os.execute("i3-msg '[instance=\""..last.."\"] scratchpad show;'")
+
+    elseif (inchan=="macro.volup") then
+	    os.execute("pactl set-sink-volume 0 +5%")
+
+    elseif (inchan=="macro.voldown") then
+	    os.execute("pactl set-sink-volume 0 -10%")
+
+    elseif (first=="sinkvol") then
+	    os.execute("pactl set-sink-volume "..last.." "..math.floor(100*(A+B*math.exp(C*v))).."%")
+
+    elseif (first=="vol") then
+	    os.execute("pactl set-sink-volume "..last.." "..v)
+	    
+    elseif (first=="srcvol") then
+	    os.execute("pactl set-source-volume "..last.." "..math.floor(100*(A+B*math.exp(C*v))).."%")
+
+    elseif (first=="dsink") then
+	    os.execute("pactl set-default-sink "..last)
+
+    elseif (first=="dsrc") then
+	    os.execute("pactl set-default-source "..last)
+
+    elseif (first=="muteall") then
+	    os.execute("~/bin/muteall")
+
+    else
+	    print("i3msg-notfound:"..first.." L:"..last.." v:"..v)
+    end
+end

--- a/configs/latch.lua
+++ b/configs/latch.lua
@@ -1,0 +1,51 @@
+-- Trackpad input by Paul Hedderly
+-- Expects two inputs - one master and one slave
+-- The first is to track a contolled input for example a
+-- sound desk fader.
+-- The slave is for a fader on a non-motorised surface...
+-- The idea is that the slave is not forwarded to the
+-- first/main output until it is close in value to the master
+-- This is to avoid sudden jumps when using a secondary
+-- non-motorised controller.
+--
+-- Example config - here using a nanok as a slave to an X32
+--
+--	[midi x32]
+--	read = X32Live
+--	write = X32Live
+--
+--	[midi nanoK]
+--	read = nanoKEY
+--	write = nanoKEY
+--
+--	[lua latch]
+--	script = latch.lua
+--	default-handler = latch
+--
+--	x32.ch0.cc1 > latch.0.master
+--	nanoK.ch0.cc1 > latch.0.slave
+--	latch.0.latched > x32.ch0.cc1
+
+threshold=0.03
+saved={}
+
+function latch(v)
+	i=input_channel(); separator=i:find("%.")
+	channel=i:sub(0,separator-1)
+	control=i:sub(1+separator,-1)
+
+	-- Setup the saved value if not yet seen
+	if saved[channel]==nil then
+		saved[channel]=v
+	end
+
+	if control == "master" then
+		saved[channel]=v
+	elseif control == "slave" then
+		diff=math.abs(v-saved[channel])
+		if diff < threshold then
+			saved[channel]=v
+			output(channel..".latched",v)
+		end
+	end
+end

--- a/configs/returnbool.lua
+++ b/configs/returnbool.lua
@@ -1,0 +1,24 @@
+-- ReturnOne by Paul Hedderly
+-- Sometimes you just want an on or off - and it might be from anything >0
+-- For example I want to activate scenes in OBS from a Korg NanoPad2
+-- But I dont want to have to thump the pads to get a 1.0 output
+--
+-- You could use this as:
+--      [midi nanoP]
+--      read = nanoPAD2
+--      write = nanoPAD2
+--      [lua trackpad]
+--      script = trackpad.lua
+--      default-handler = returnone
+-- ..   
+-- 	nanoP.ch0.note{36..51} > returnone.one{1..16} -- To feed all the 16 pads to 
+--	returnone.outone1 > obs./obs/scene/1/preview
+--	returnone.outone2 > obs./obs/scene/2/preview
+-- etc
+-- The output channel will be the same as the channel you feed prepended "out"
+
+
+function returnbool(v) -- Use a default function - then you can use any input channel name
+  if v>0 then output("out"..input_channel(),1) end;
+  if v==0 then output("out"..input_channel(),0) end;
+end

--- a/configs/returnjustone.lua
+++ b/configs/returnjustone.lua
@@ -1,0 +1,23 @@
+-- ReturnOne by Paul Hedderly
+-- Sometimes you just want just an on - and from any imput but 0
+-- For example I want to activate scenes in OBS from a Korg NanoPad2
+-- But I dont want to have to thump the pads to get a 1.0 output
+--
+-- You could use this as:
+--      [midi nanoP]
+--      read = nanoPAD2
+--      write = nanoPAD2
+--      [lua trackpad]
+--      script = trackpad.lua
+--      default-handler = returnone
+-- ..   
+-- 	nanoP.ch0.note{36..51} > returnone.one{1..16} -- To feed all the 16 pads to 
+--	returnone.outone1 > obs./obs/scene/1/preview
+--	returnone.outone2 > obs./obs/scene/2/preview
+-- etc
+-- The output channel will be the same as the channel you feed prepended "out"
+
+
+function returnjustone(v) -- Use a default function - then you can use any input channel name
+  if v>0 then output("out"..input_channel(),1) end;
+end


### PR DESCRIPTION
I've committed some more examples that might help others.

prh: new example config to latch a non-motorised fader
prh: new example config bool - turn pads into 0/1 output
prh: new example return just one - like bool, but just one
prh: Some examples using os.execute - in this case driving i3 window manager shortcuts and system volumes

The latching example I think is very useful. There might be a better way to do it, but this works really well for me.

Thanks again for MM - it is such an awesome multi-tool.