### PR TITLE
Fix some cases of `make install` not installing the config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ install:
 	install -m 0644 configs/* "$(DESTDIR)$(EXAMPLES)"
 ifdef DEFAULT_CFG
 # Only install the default configuration if it is not already present to avoid overwriting it
-ifeq (,$(wildcard $(DEFAULT_CFG)))
+ifeq (,$(wildcard $(DESTDIR)$(DEFAULT_CFG)))
 	install -Dm 0644 monster.cfg "$(DESTDIR)$(DEFAULT_CFG)"
 endif
 endif


### PR DESCRIPTION
To reproduce the issue:
1. build and install midimonster so there is an `/etc/midimonster/midimonster.cfg` (or similar) on your system
2. create a temporary directory `out` and run `make DESTDIR=./out DEFAULT_CFG=/etc/midimonster/midimonster.cfg`
3. the `./out` directory does not contain the config at the desired path

This can happen when building a package for distribution, like I'm doing right now (https://github.com/osam-cologne/archlinux-proaudio/pull/25) and after installing it for testing you want to package it again...

My fix does not cover spaces in the `DESTDIR` or `DEFAULT_CFG` variables (because of how `wildcard` works), but that would not have worked before anyway.