### PR TITLE
Fix CXXFLAGS for OLA backend

### DIFF
--- a/backends/Makefile
+++ b/backends/Makefile
@@ -18,11 +18,11 @@ SYSTEM := $(shell uname -s)
 
 # Generate debug symbols unless overridden
 CFLAGS ?= -g
-CPPFLAGS ?= -g
+CXXFLAGS ?= -g
 
 # All backends are shared libraries
 CFLAGS += -fPIC -I../ -Wall -Wpedantic
-CPPFLAGS += -fPIC -I../
+CXXFLAGS += -fPIC -I../
 LDFLAGS += -shared
 
 # Build Linux backends if possible
@@ -82,7 +82,7 @@ midi.so: LDLIBS = -lasound
 evdev.so: CFLAGS += $(shell pkg-config --cflags libevdev || echo "-DBUILD_ERROR=\"Missing pkg-config data for libevdev\"")
 evdev.so: LDLIBS = $(shell pkg-config --libs libevdev || echo "-DBUILD_ERROR=\"Missing pkg-config data for libevdev\"")
 ola.so: LDLIBS = -lola
-ola.so: CPPFLAGS += -Wno-write-strings
+ola.so: CXXFLAGS += -std=c++11 -Wno-write-strings
 
 # The pkg-config name for liblua5.3 is subject to discussion. I prefer 'lua5.3' (which works on Debian and OSX),
 # but Arch requires 'lua53' which works on Debian, too, but breaks on OSX.
@@ -108,7 +108,7 @@ python.dll: LDLIBS += -L../ -lpython3
 	$(CC) $(CFLAGS) $< $(ADDITIONAL_OBJS) -o $@ $(LDFLAGS) $(LDLIBS)
 
 %.so :: %.cpp %.h
-	$(CXX) $(CPPFLAGS) $< $(ADDITIONAL_OBJS) -o $@ $(LDFLAGS) $(LDLIBS)
+	$(CXX) $(CXXFLAGS) $< $(ADDITIONAL_OBJS) -o $@ $(LDFLAGS) $(LDLIBS)
 
 # This is the actual first named target, and thus the default
 all: $(BACKEND_LIB) $(BACKENDS)


### PR DESCRIPTION
When compiling the `full` target with OLA 0.10.8 installed on Arch Linux, the compiler throws errors for stdc++ used in the OLA DMX headers, like
```
In file included from /usr/include/c++/11.2.0/algorithm:62,
                 from /usr/include/ola/rdm/UIDSet.h:33,
                 from /usr/include/ola/client/CallbackTypes.h:33,
                 from /usr/include/ola/client/OlaClient.h:25,
                 from /usr/include/ola/client/ClientWrapper.h:40,
                 from /usr/include/ola/OlaClientWrapper.h:25,
                 from ola.cpp:7:
/usr/include/c++/11.2.0/bits/stl_algo.h:3677:7: error: expected unqualified-id before ‘return’
 3677 |       return __comp(__val, __lo) ? __lo : __comp(__hi, __val) ? __hi : __val;
      |       ^~~~~~
/usr/include/c++/11.2.0/bits/stl_algo.h:3705:5: error: ‘pair’ does not name a type
 3705 |     pair<_IntType, _IntType>
      |     ^~~~
...
```
Compiling with `-std=c++11` fixes this, so I added that to the `CPPFLAGS` for the OLA backend only. Everything starts but I didn't do any further testing with that backend yet.