### PR TITLE
set evdev key threshold to 0.5

### DIFF
--- a/backends/evdev.c
+++ b/backends/evdev.c
@@ -478,7 +478,7 @@ static int evdev_set(instance* inst, size_t num, channel** c, channel_value* v) 
 			case EV_KEY:
 			case EV_SW:
 			default:
-				value = (v[evt].normalised > 0.9) ? 1 : 0;
+				value = (v[evt].normalised > 0.5) ? 1 : 0;
 				break;
 		}
 

--- a/backends/evdev.md
+++ b/backends/evdev.md
@@ -79,7 +79,7 @@ Input devices may synchronize logically connected event types (for example, X an
 events. The MIDIMonster also generates these events after processing channel events, but may not keep the original
 event grouping.
 
-`EV_KEY` key-down events are sent for normalized channel values over `0.9`.
+`EV_KEY` key-down events are sent for normalized channel values over `0.5`.
 
 Extended event type values such as `EV_LED`, `EV_SND`, etc are recognized in the MIDIMonster configuration file
 but may or may not work with the internal channel mapping and normalization code.


### PR DESCRIPTION
Hi. Many midi devices that don't have velocity sensitivity usually send notes with velocity values like 64, 96 or 100 (out of 127). This means that those keypresses are not recognised by midimonster. 127 is rarely used as it'd correspond to maximum piano key velocity, which wouldn't sound musical, unlike less extreme values. This patch sets the threshold at 0.5 which fixes the problem for my Behringer FCB1010. Ideally it'd probably make sense to make the key velocity threshold configurable, but I'm not the best C programmer to do that.