### PR TITLE
Fix midi pitch output on aarch64 devices

### DIFF
--- a/backends/midi.c
+++ b/backends/midi.c
@@ -247,8 +247,7 @@ static int midi_set(instance* inst, size_t num, channel** c, channel_value* v){
 				}
 				break;
 			case pitchbend:
-				//TODO check whether this actually works that well
-				midi_tx(data->port, ident.fields.type, ident.fields.channel, ident.fields.control, (v[u].normalised * 16383.0) - 8192);
+				midi_tx(data->port, ident.fields.type, ident.fields.channel, ident.fields.control, (int16_t) (v[u].normalised * 16383.0) - 8192);
 				break;
 			default:
 				midi_tx(data->port, ident.fields.type, ident.fields.channel, ident.fields.control, v[u].normalised * 127.0);


### PR DESCRIPTION
When compiling for the RaspberryPi4, all negative values sent to Midi-Pitch channels would be clipped to 0, resetting the fader to the center position.